### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+/.gitattributes export-ignore
+/.gitignore     export-ignore
+/README.md      export-ignore


### PR DESCRIPTION
This way, people who require the package won't get the `.gitattributes`, `.gitignore` and `readme.md` files.