### PR TITLE
Allow Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
   ],
   "require": {
     "php": ">=5.6.4",
-    "illuminate/support": "5.4.*",
-    "illuminate/mail": "5.4.*"
+    "illuminate/support": "5.*.*",
+    "illuminate/mail": "5.*.*"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
   ],
   "require": {
     "php": ">=5.6.4",
-    "illuminate/support": "^5.4.*",
-    "illuminate/mail": "^5.4.*"
+    "illuminate/support": "5.*.*",
+    "illuminate/mail": "5.*.*"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
   ],
   "require": {
     "php": ">=5.6.4",
-    "illuminate/support": "5.*.*",
-    "illuminate/mail": "5.*.*"
+    "illuminate/support": ">=5.4.0",
+    "illuminate/mail": ">=5.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
   ],
   "require": {
     "php": ">=5.6.4",
-    "illuminate/support": "5.*.*",
-    "illuminate/mail": "5.*.*"
+    "illuminate/support": "^5.4.*",
+    "illuminate/mail": "^5.4.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This will allow newer versions of illuminate/support & illuminate/mail to be used. So this package can work with Laravel 5.5